### PR TITLE
feat: Add `setTouched` to manage state `touched` correctly

### DIFF
--- a/src/demo/App.tsx
+++ b/src/demo/App.tsx
@@ -54,8 +54,8 @@ const App = () => {
 
   React.useEffect(() => {
     // eslint-disable-next-line
-    console.log(formGroup);
-  }, [formGroup]);
+    console.log(formGroup.values);
+  }, [formGroup.values]);
 
   return (
     <div className="App">

--- a/src/demo/CheckboxField.tsx
+++ b/src/demo/CheckboxField.tsx
@@ -7,7 +7,15 @@ interface Props {
 }
 
 export const CheckboxField: React.FC<Props> = ({ checkboxes }) => {
-  const { value: currentValue, setValue, errors, ...meta } = useFormControl("checkbox");
+  const {
+    value: currentValue,
+    setValue,
+    errors,
+    inputRef,
+    selectRef: _selectRef,
+    textareaRef: _textareaRef,
+    ...meta
+  } = useFormControl("checkbox");
   return (
     <>
       {checkboxes.map(checkbox => {
@@ -26,6 +34,7 @@ export const CheckboxField: React.FC<Props> = ({ checkboxes }) => {
                   setValue([...currentValue.filter((v: any) => v !== value)]);
                 }
               }}
+              ref={inputRef}
             />
             <span>{checkbox.value}</span>
           </label>

--- a/src/demo/RadioField.tsx
+++ b/src/demo/RadioField.tsx
@@ -7,7 +7,15 @@ interface Props {
 }
 
 export const RadioField: React.FC<Props> = ({ radios }) => {
-  const { value, setValue, errors, ...meta } = useFormControl("radio");
+  const {
+    value,
+    setValue,
+    errors,
+    inputRef,
+    selectRef: _selectRef,
+    textareaRef: _textareaRef,
+    ...meta
+  } = useFormControl("radio");
   return (
     <>
       {radios.map(radio => {
@@ -20,6 +28,7 @@ export const RadioField: React.FC<Props> = ({ radios }) => {
               value={radio.value}
               onChange={e => setValue(e.target.value)}
               checked={value === radio.value}
+              ref={inputRef}
             />
             <span>{radio.key}</span>
           </label>

--- a/src/demo/SelectField.tsx
+++ b/src/demo/SelectField.tsx
@@ -7,10 +7,18 @@ interface Props {
 }
 
 export const SelectField: React.FC<Props> = ({ options }) => {
-  const { value, setValue, errors, ...meta } = useFormControl("select");
+  const {
+    value,
+    setValue,
+    errors,
+    inputRef: _inputRef,
+    selectRef,
+    textareaRef: _textareaRef,
+    ...meta
+  } = useFormControl("select");
   return (
     <>
-      <select name="select" value={value} onChange={e => setValue(e.target.value)}>
+      <select name="select" value={value} onChange={e => setValue(e.target.value)} ref={selectRef}>
         {options.map(option => {
           return (
             <option key={option.key} value={option.value}>

--- a/src/demo/TextField.tsx
+++ b/src/demo/TextField.tsx
@@ -5,10 +5,24 @@ import { MetaAndErrors } from "./MetaAndErrors";
 import "./FormItem.css";
 
 export const TextField = () => {
-  const { value, setValue, errors, ...meta } = useFormControl("text");
+  const {
+    value,
+    setValue,
+    errors,
+    inputRef,
+    selectRef: _selectRef,
+    textareaRef: _textareaRef,
+    ...meta
+  } = useFormControl("text");
   return (
     <div className="TextField">
-      <input type="text" className="TextField__input" value={value} onChange={e => setValue(e.target.value)} />
+      <input
+        type="text"
+        className="TextField__input"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        ref={inputRef}
+      />
       <MetaAndErrors meta={meta} errors={errors} />
     </div>
   );

--- a/src/lib/react-form-control/FieldControl.tsx
+++ b/src/lib/react-form-control/FieldControl.tsx
@@ -10,6 +10,9 @@ export interface FieldControlChildrenProps {
   untouched: boolean;
   errors: ValidatorErrors;
   setValue: (value: any) => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  selectRef: React.RefObject<HTMLSelectElement | null>;
 }
 
 interface FieldControlProps {

--- a/src/lib/react-form-control/__tests__/FieldControl.test.tsx
+++ b/src/lib/react-form-control/__tests__/FieldControl.test.tsx
@@ -15,11 +15,19 @@ const MockComponent: React.FC<{}> = () => {
   return (
     <FormGroupProvider formGroup={formGroup}>
       <FieldControl name="text">
-        {({ value, setValue }) => {
+        {({ value, setValue, inputRef, touched, untouched }) => {
           return (
             <>
-              <input type="text" value={value} onChange={e => setValue(e.target.value)} data-testid="input" />;
-              <span data-testid="value">{value}</span>
+              <input
+                type="text"
+                value={value}
+                onChange={e => setValue(e.target.value)}
+                ref={inputRef}
+                data-testid="input"
+              />
+              ;<span data-testid="value">{value}</span>
+              <span data-testid="touched">{touched ? "true" : "false"}</span>
+              <span data-testid="untouched">{untouched ? "true" : "false"}</span>
             </>
           );
         }}
@@ -41,6 +49,19 @@ describe("FieldControl", () => {
     expect(value.innerHTML).toBe("");
     fireEvent.change(input, { target: { value: "abc" } });
     expect(value.innerHTML).toBe("abc");
+  });
+
+  it("adds onBlur event listener on mount", () => {
+    const { getByTestId } = render(<MockComponent />);
+    const input = getByTestId("input");
+    const touched = getByTestId("touched");
+    const untouched = getByTestId("untouched");
+    expect(touched.innerHTML).toBe("false");
+    expect(untouched.innerHTML).toBe("true");
+    input.focus();
+    input.blur();
+    expect(touched.innerHTML).toBe("true");
+    expect(untouched.innerHTML).toBe("false");
   });
 });
 

--- a/src/lib/react-form-control/__tests__/FieldControl.test.tsx
+++ b/src/lib/react-form-control/__tests__/FieldControl.test.tsx
@@ -25,7 +25,7 @@ const MockComponent: React.FC<{}> = () => {
                 ref={inputRef}
                 data-testid="input"
               />
-              ;<span data-testid="value">{value}</span>
+              <span data-testid="value">{value}</span>
               <span data-testid="touched">{touched ? "true" : "false"}</span>
               <span data-testid="untouched">{untouched ? "true" : "false"}</span>
             </>

--- a/src/lib/react-form-control/__tests__/FieldControl.test.tsx
+++ b/src/lib/react-form-control/__tests__/FieldControl.test.tsx
@@ -86,3 +86,31 @@ describe("FieldControl", () => {
     }
   });
 });
+
+const MockComponentWithoutRef: React.FC<{}> = () => {
+  const formGroup = useFormGroup({
+    values: {
+      text: "",
+    },
+  });
+  return (
+    <FormGroupProvider formGroup={formGroup}>
+      <FieldControl name="text">
+        {({ value, setValue }) => {
+          return (
+            <>
+              <input type="text" value={value} onChange={e => setValue(e.target.value)} data-testid="input" />
+            </>
+          );
+        }}
+      </FieldControl>
+    </FormGroupProvider>
+  );
+};
+
+describe("FieldControl without inputRef", () => {
+  it("works correctly without *Ref", () => {
+    const container = render(<MockComponentWithoutRef />);
+    expect(container).toBeTruthy();
+  });
+});

--- a/src/lib/react-form-control/__tests__/useFormGroup.test.tsx
+++ b/src/lib/react-form-control/__tests__/useFormGroup.test.tsx
@@ -221,4 +221,36 @@ describe("useFormGroup", () => {
     await waitForNextUpdate();
     expect(result.current.values).toEqual({ num: 1 });
   });
+
+  it("can update touched/untouched via setTouchedOnBlur", async () => {
+    const { result } = renderHook(() =>
+      useFormGroup({
+        values: {
+          num: 0,
+        },
+      })
+    );
+
+    expect(result.current.metaInfos).toEqual({
+      num: {
+        pristine: true,
+        dirty: false,
+        touched: false,
+        untouched: true,
+      },
+    });
+
+    act(() => {
+      result.current.setTouchedOnBlur("num");
+    });
+
+    expect(result.current.metaInfos).toEqual({
+      num: {
+        pristine: true,
+        dirty: false,
+        touched: true,
+        untouched: false,
+      },
+    });
+  });
 });

--- a/src/lib/react-form-control/useFormControl.ts
+++ b/src/lib/react-form-control/useFormControl.ts
@@ -17,7 +17,7 @@ export function useFormControl<T>(name: string) {
   const setValue = useCallback((value: any) => formGroup.setValue({ [name]: value }), [formGroup, name]);
 
   useEffect(() => {
-    const element = inputRef.current || selectRef.current;
+    const element = inputRef.current || textareaRef.current || selectRef.current;
     if (!element) {
       return;
     }
@@ -26,6 +26,7 @@ export function useFormControl<T>(name: string) {
     return () => {
       element.removeEventListener("blur", onBlur);
     };
+    // NOTE: Call this effect onMount only.
     /* eslint-disable-next-line */
   }, []);
 

--- a/src/lib/react-form-control/useFormControl.ts
+++ b/src/lib/react-form-control/useFormControl.ts
@@ -1,20 +1,41 @@
-import { useContext, useCallback } from "react";
+import { useContext, useCallback, useRef, useEffect } from "react";
 import { FieldContext } from "./FormGroupContext";
 
 export function useFormControl<T>(name: string) {
   const formGroup = useContext(FieldContext);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const selectRef = useRef<HTMLSelectElement | null>(null);
+
   if (formGroup === null) {
     throw new Error(
       ['Could not find "formGroup" in context.', "Wrap the root component in a <FormGroupProvider>."].join(" ")
     );
   }
 
-  const { values, metaInfos, errors } = formGroup;
+  const { values, metaInfos, errors, setTouchedOnBlur } = formGroup;
   const setValue = useCallback((value: any) => formGroup.setValue({ [name]: value }), [formGroup, name]);
+
+  useEffect(() => {
+    const element = inputRef.current || selectRef.current;
+    if (!element) {
+      return;
+    }
+    const onBlur = () => setTouchedOnBlur(name);
+    element.addEventListener("blur", onBlur);
+    return () => {
+      element.removeEventListener("blur", onBlur);
+    };
+    /* eslint-disable-next-line */
+  }, []);
+
   return {
     value: values[name],
     ...metaInfos[name],
     errors: errors[name],
     setValue,
+    inputRef,
+    selectRef,
+    textareaRef,
   };
 }

--- a/src/lib/react-form-control/useFormGroup.ts
+++ b/src/lib/react-form-control/useFormGroup.ts
@@ -26,6 +26,7 @@ export interface FormGroup {
   values: any;
   errors: ValidatorErrors;
   reset: () => void;
+  setTouchedOnBlur: (key: string) => void;
 }
 
 export function initMeta<T>(values: T) {
@@ -136,6 +137,17 @@ export function useFormGroup<T>(formGroupOptions: FormGroupOptions<T>): FormGrou
     [initialValues, validators]
   );
 
+  const setTouchedOnBlur = useCallback((key: string) => {
+    setMetaInfo(currentMetas => ({
+      ...currentMetas,
+      [key]: {
+        ...currentMetas[key],
+        touched: true,
+        untouched: false,
+      },
+    }));
+  }, []);
+
   useEffect(() => {
     let hasError = false;
     Object.values(errors).forEach(e => {
@@ -156,5 +168,6 @@ export function useFormGroup<T>(formGroupOptions: FormGroupOptions<T>): FormGrou
     values,
     errors,
     reset,
+    setTouchedOnBlur,
   };
 }


### PR DESCRIPTION
I want to update `touched` and `untouched` on blur instead of updating it on value update.